### PR TITLE
fix: renovate rebase

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,9 @@
 BUILD_HARNESS_REPO=ghcr.io/defenseunicorns/build-harness/build-harness
 # renovate: datasource=github-tags depName=defenseunicorns/build-harness
-BUILD_HARNESS_VERSION=2.0.34
+BUILD_HARNESS_VERSION=2.0.38
 # renovate: datasource=github-tags depName=defenseunicorns/uds-core
-UDS_CORE_VERSION=0.25.0
+UDS_CORE_VERSION=0.26.1
 # renovate: datasource=github-tags depName=defenseunicorns/uds-cli
-UDS_CLI_VERSION=0.14.0
+UDS_CLI_VERSION=0.14.2
 # renovate: datasource=github-tags depName=k3d-io/k3d
 K3D_VERSION=5.7.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: fix-smartquotes
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.92.1
+    rev: v1.94.1
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -37,6 +37,6 @@ repos:
         args:
           - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 38.18.14
+    rev: 38.68.0
     hooks:
       - id: renovate-config-validator

--- a/renovate.json5
+++ b/renovate.json5
@@ -44,7 +44,7 @@
         "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?(?<currentValue>.*)\\s"
       ],
       versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
-      extractVersionTemplate: ".*^v?(?<version>.*)$"
+      extractVersionTemplate: "^v?(?<version>.*)$"
     }
   ],
   packageRules: [

--- a/renovate.json5
+++ b/renovate.json5
@@ -41,7 +41,8 @@
       customType: "regex",
       fileMatch: [".*\.[yaml|yml]"],
       matchStrings: [
-        "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?(?<currentValue>.*)\\s"
+        "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?version: (?<currentValue>.*)\\s",
+        "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?:v(?<currentValue>.*)\\s"
       ],
       versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
       extractVersionTemplate: "^v?(?<version>.*)$"

--- a/renovate.json5
+++ b/renovate.json5
@@ -44,7 +44,7 @@
         "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?(?<currentValue>.*)\\s"
       ],
       versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
-      extractVersionTemplate: "^v?(?<version>.*)$"
+      extractVersionTemplate: ".*^v?(?<version>.*)$"
     }
   ],
   packageRules: [

--- a/test/tasks/ci.yaml
+++ b/test/tasks/ci.yaml
@@ -26,7 +26,7 @@ tasks:
       - dir: test
         shell:
           darwin: bash
-          linuix: bash
+          linux: bash
         cmd: |
           set -a; source ../.env; set +a
           uds remove k3d-core-slim-dev:${UDS_CORE_VERSION} -c

--- a/test/tasks/ci.yaml
+++ b/test/tasks/ci.yaml
@@ -23,7 +23,11 @@ tasks:
   - name: uds-down
     description: Brings down uds-slim-dev and everything it contains
     actions:
-      - cmd: |
+      - dir: test
+        shell:
+          darwin: bash
+          linuix: bash
+        cmd: |
           set -a; source ../.env; set +a
           uds remove k3d-core-slim-dev:${UDS_CORE_VERSION} -c
       - cmd: k3d cluster delete uds

--- a/test/tasks/ci.yaml
+++ b/test/tasks/ci.yaml
@@ -23,7 +23,9 @@ tasks:
   - name: uds-down
     description: Brings down uds-slim-dev and everything it contains
     actions:
-      - cmd: uds remove k3d-core-slim-dev:${UDS_CORE_VERSION} -c
+      - cmd: |
+          set -a; source ../.env; set +a
+          uds remove k3d-core-slim-dev:${UDS_CORE_VERSION} -c
       - cmd: k3d cluster delete uds
   - name: package-up
     description: Builds and deploys the zarf package using the test zarf-config.yaml

--- a/test/tasks/ci.yaml
+++ b/test/tasks/ci.yaml
@@ -23,6 +23,7 @@ tasks:
   - name: uds-down
     description: Brings down uds-slim-dev and everything it contains
     actions:
+      - cmd: uds remove k3d-core-slim-dev:${UDS_CORE_VERSION} -c
       - cmd: k3d cluster delete uds
   - name: package-up
     description: Builds and deploys the zarf package using the test zarf-config.yaml

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -28,7 +28,6 @@ variables:
     sensitive: true
   - name: PG_STORAGE_CLASS
     description: Storage class for postgresql
-    default: null
   - name: ARCHIVE_TTL
     description: Time to keep archived workflows in Postgres
     default: 10d
@@ -51,7 +50,6 @@ variables:
     sensitive: true
   - name: S3_PORT
     description: Port to connect to S3 API on
-    default: 443
   - name: DEFAULT_ARTIFACT_REPO
     prompt: true
     sensitive: false
@@ -176,8 +174,7 @@ components:
     charts:
       - name: argo-workflows
         namespace: argo
-        # renovate: datasource=docker depName=ghcr.io/argoproj/argo-helm/argo-workflows
-0.42.1
+        version: 0.42.1 # renovate: datasource=docker depName=ghcr.io/argoproj/argo-helm/argo-workflows
         url: oci://ghcr.io/argoproj/argo-helm/argo-workflows
         valuesFiles:
           - values/workflow-values.yaml
@@ -208,8 +205,7 @@ components:
     charts:
       - name: argo-workflows
         namespace: argo
-        # renovate: datasource=docker depName=ghcr.io/argoproj/argo-helm/argo-workflows
-0.42.1
+        version: 0.42.1 # renovate: datasource=docker depName=ghcr.io/argoproj/argo-helm/argo-workflows
         url: oci://ghcr.io/argoproj/argo-helm/argo-workflows
         valuesFiles:
           - values/workflow-values.yaml

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -177,7 +177,7 @@ components:
       - name: argo-workflows
         namespace: argo
         # renovate: datasource=docker depName=ghcr.io/argoproj/argo-helm/argo-workflows
-        version: 0.41.14
+0.42.1
         url: oci://ghcr.io/argoproj/argo-helm/argo-workflows
         valuesFiles:
           - values/workflow-values.yaml
@@ -209,7 +209,7 @@ components:
       - name: argo-workflows
         namespace: argo
         # renovate: datasource=docker depName=ghcr.io/argoproj/argo-helm/argo-workflows
-        version: 0.41.14
+0.42.1
         url: oci://ghcr.io/argoproj/argo-helm/argo-workflows
         valuesFiles:
           - values/workflow-values.yaml

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -174,7 +174,8 @@ components:
     charts:
       - name: argo-workflows
         namespace: argo
-        version: 0.42.1 # renovate: datasource=docker depName=ghcr.io/argoproj/argo-helm/argo-workflows
+        # renovate: datasource=helm depName=ghcr.io/argoproj/argo-helm/argo-workflows
+        version: 0.42.1
         url: oci://ghcr.io/argoproj/argo-helm/argo-workflows
         valuesFiles:
           - values/workflow-values.yaml
@@ -205,7 +206,8 @@ components:
     charts:
       - name: argo-workflows
         namespace: argo
-        version: 0.42.1 # renovate: datasource=docker depName=ghcr.io/argoproj/argo-helm/argo-workflows
+        # renovate: datasource=helm depName=ghcr.io/argoproj/argo-helm/argo-workflows
+        version: 0.42.1
         url: oci://ghcr.io/argoproj/argo-helm/argo-workflows
         valuesFiles:
           - values/workflow-values.yaml


### PR DESCRIPTION
Fixes some issues with the most recent dependency update.  Most notabl:
* uds cli needs to have default values for zarf variabels be strings now
* renovate on the chart versions was deleting the `version: ` preamble for some reason in the zarf package.