### PR TITLE
chore(docs): update LICENSE and CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,5 @@
 /* @ldgriswold @RothAndrew
+
+/CODEOWNERS @defenseunicorns-partnerships/wfapi
+
+/LICENS* @jeff-mccoy @austenbryan

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 Defense Unicorns
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Adds `wfapi` team as CODEOWNERS
* Adds Jeff McCoy and Austen Bryan as License owners
* Fixes apache license syntax