### PR TITLE
fix: change POST rules to check presenter vice client_id

### DIFF
--- a/manifests/authorization.yaml
+++ b/manifests/authorization.yaml
@@ -16,5 +16,5 @@ spec:
         ports:
           - "2746"
     when:
-      - key: request.auth.claims[client_id]
+      - key: request.auth.presenter
         notValues: ["server-api"]


### PR DESCRIPTION
New UDS Core Keycloak no longer attaches the client_id field to serviceAccount JWTs, so I switched the rule to the presenter (azp field).